### PR TITLE
Add support for Rotten Tomatoes and new TPB domains

### DIFF
--- a/contentscript_imdb.js
+++ b/contentscript_imdb.js
@@ -54,6 +54,34 @@
 				}
 			});
 		};
+
+		var thisIsRottenTomatoes = window.location.href.indexOf('//www.rottentomatoes.com/') > 0;
+		if(thisIsRottenTomatoes){
+				var thisIsAMoviePage = window.location.href.indexOf('/m/') > 0;
+				if(thisIsAMoviePage){
+					var container = $('<div class="col-sm-7 col-xs-9"></div>');
+					var tmpSearchTerm = $('#movie-title').clone();
+					$(tmpSearchTerm).find(".h3").remove();
+					var searchTerm = $(tmpSearchTerm).text();
+
+					$(container).insertBefore("#movie_videos");
+					container.css('clear', 'left');
+					container.tpbSearch({'searchTerm' : searchTerm });
+				}
+
+				var thisIsATVPage = window.location.href.indexOf('/tv/') > 0;
+				if(thisIsATVPage){
+					var container = $('<div class="col-sm-7 col-xs-9"></div>');
+					var tmpSearchTerm = $('#movie-title').clone();
+					$(tmpSearchTerm).find(".h3").remove();
+					var searchTerm = $(tmpSearchTerm).text();
+
+					$(container).insertBefore("#movie_videos");
+					container.css('clear', 'left');
+					container.tpbSearch({'searchTerm' : searchTerm });
+				}
+			//});
+		};
 	};
 }(jQuery));
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,26 @@
 {   
 	"manifest_version": 2, 
 	"name": "TPB IMDB Pirate Bay Search Plugin",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"description": "Search The Pirate Bay from IMDB.",
 	"permissions": [
 		"tabs",
-		"http://*.thepiratebay.cr/",
-		"http://thepiratebay.cr/"
+		"http://thepiratebay.org/",
+		"https://thepiratebay.org/",
+		"http://thepiratebay.se/",
+		"https://thepiratebay.se/",
+		"http://thepiratebay.mn/",
+		"https://thepiratebay.mn/",
+		"http://thepiratebay.gd/",
+		"https://thepiratebay.gd/",
+		"http://thepiratebay.vg/",
+		"https://thepiratebay.vg/",
+		"http://thepiratebay.la/",
+		"https://thepiratebay.la/",
+		"http://rottentomatoes.com/",
+		"http://*.rottentomatoes.com/",
+		"https://rottentomatoes.com/",
+		"https://*.rottentomatoes.com/"
 	],   
 	"icons": {
 		"16": "images/icon.png",
@@ -20,7 +34,7 @@
     ],
   	"content_scripts": [
     {
- 	  "matches": ["http://www.imdb.com/*", "https://www.imdb.com/*"],
+ 	  "matches": ["http://www.imdb.com/*", "https://www.imdb.com/*", "http://www.rottentomatoes.com/*", "https://www.rottentomatoes.com/*"],
       "css": ["bootstrap/css/bootstrap.css"], 
       "js": ["jquery-1.9.1.min.js", "tpbImdbPirateBaySearch.plugin.js", "contentscript_imdb.js"]
     }

--- a/tpbImdbPirateBaySearch.plugin.js
+++ b/tpbImdbPirateBaySearch.plugin.js
@@ -14,7 +14,7 @@
 
 	function buildSearchUrl(searchTerm)
 	{
-		var searchUrl = '//thepiratebay.cr/search/' + encodeURIComponent(searchTerm) + '/0/7/0';
+		var searchUrl = '//thepiratebay.org/search/' + encodeURIComponent(searchTerm) + '/0/7/0';
 		return searchUrl;
 	}
 


### PR DESCRIPTION
- Added support for Rotten Tomatoes Movie and TV pages
- Uses TPB's .org domain, which then redirects to either .mn, .gd, .vg, or .la
